### PR TITLE
Revert "04_未完成のテストコード修正"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,9 +116,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
+    mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,15 +1,9 @@
 FactoryBot.define do
   factory :task do
     title { 'Task' }
-    status { :todo }
+    status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
-    association :project
-
-    trait :done do
-      status { :done }
-      completion_date { Time.current.yesterday }
-    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,5 +59,4 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
-  config.include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,25 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
-  let(:project) { create(:project) }
-  let(:task) { create(:task) }
-  let(:task_done) { create(:task, :done) }
-
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
         click_link 'View Todos'
-        switch_to_window(windows.last)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
@@ -31,6 +30,7 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください
+        project = FactoryBot.create(:project)
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
@@ -46,6 +46,8 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -57,18 +59,22 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(short_time(Time.current))
+        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
         expect(current_path).to eq project_tasks_path(project)
       end
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
         # TODO: ローカル変数ではなく let を使用してください
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'
@@ -79,26 +85,28 @@ RSpec.describe 'Task', type: :system do
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        visit edit_project_task_path(project, task_done)
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
+        visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
-        expect(current_path).to eq project_task_path(project, task_done)
+        expect(current_path).to eq project_task_path(project, task)
       end
     end
   end
 
   describe 'Task削除' do
-    let!(:task) { create(:task) }
-
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      it 'Taskが削除されること' do
+      xit 'Taskが削除されること' do
+        project = FactoryBot.create(:project)
+        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(find('.task_list')).not_to have_content task.title
+        expect(page).not_to have_content task.title
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end


### PR DESCRIPTION
① FactoryBot.の省略
```
rails_helperで、`config.include FactoryBot::Syntax::Methods`と定義されているので、project = FactoryBot.create(:project)の際の`FactoryBot.`を省略した。
```

② local変数をletへ変更
```
project = FactoryBot.create(:project)
task = FactoryBot.create(:task, project_id: project.id)
↓
let(:project) { create(:project) }
let(:task) { create(:task, project_id: project.id) }
```

③ taskとprojectのアソシエーションの追加
```
(factories/task.rb)
association :project　追記することで、

(system/task_spec.rb )
task = FactoryBot.create(:task, project_id: project.id)の`project_id: project.id`が省略可能になる。
↓
task = FactoryBot.create(:task)
```

④ FactoryBotのtraitを利用
```
(factories/tasks.rb)
trait :done do
　status { :done }
　completion_date { Time.current.yesterday }
end
traitを利用することで、
(system/task_spec.rb )
task = create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
↓
この長いコードを
let(:task_done) { create(:task, :done) }
と省略可能になる。
```

⑤ Taskが削除されるテスト
```
byebugで確認すると、taskの中身が空になっていた。letをlet!に変更して遅延評価されないようにした。
`expect(page).not_to have_content task.title`となっていた。これだと範囲が広いので、pageの部分を
`(find('.task_list'))`とクラス名を指定して範囲を絞り込む。
```

⑥ Taskを編集した場合、一覧画面で編集後の内容が表示されるテスト
```
`Time.current.strftime('%Y-%m-%d')`の部分に注目した。viewとの表記が異なっていたためテストがパスしなかった。
viewでは、('%-m/%d %H:%M')表示形式だった。
viewと同じメソッドを使うとのことだったので、`short_time(Time.current)`へと変更。
しかし、これでテストを実行するとエラーになるので、`short_time`メソッドをincludeする設定を追記。
(rails_helper.rb)
config.include ApplicationHelper
```

⑦ Project詳細からTask一覧ページにアクセスした場合、Taskが表示されるテスト
```
テストを実行すると別タブが開木、そのウィンドウに遷移していないためにテストが実行できずにエラーが出ていた。
`switch_to_window(windows.last)`　を追記して
別タブに移動して操作する事ができるように変更した。
```

[![Image from Gyazo](https://i.gyazo.com/25048ca5f58ef69c00449120e945ad6f.png)](https://gyazo.com/25048ca5f58ef69c00449120e945ad6f)